### PR TITLE
Upgrade HUGO version

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.123.3
+      HUGO_VERSION: 0.141.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/layouts/_default/about.html
+++ b/layouts/_default/about.html
@@ -40,10 +40,10 @@
             {{ range $column, $elements := .Params.featured_images }}
               <div class="col {{ if eq $column "column1" }}pt-lg-5 mt-lg-1{{ end }}">
                 {{ range $index_j, $element := $elements }}
-                  {{ with resources.GetRemote $element.url }}
+                  {{ with try (resources.GetRemote $element.url) }}
                     {{ with .Err }}
                       {{ warnf "%s" . }}
-                    {{ else }}
+                    {{ else with .Value }}
                       {{ $image := $element.size | default "800x900 center webp" | .Fill }}
                       <img
                         src="{{ $image.RelPermalink }}"
@@ -52,6 +52,8 @@
                         class="d-block rounded-3 {{ if eq $index_j 0 }}mb-3 mb-lg-4{{ end }}"
                         alt="{{ $element.alt }}"
                       />
+                    {{ else }}
+                      {{ warnf "Failed to get remote resource: %s" . }}
                     {{ end }}
                   {{ end }}
                 {{ end }}
@@ -131,12 +133,14 @@
           data-sub-html='<h6 class="fs-sm text-light">PFYSS Introduction Video</h6>'
         >
           {{/* Get Vedeo Cover Image */}}
-          {{ with resources.GetRemote .Params.video.cover }}
+          {{ with try (resources.GetRemote .Params.video.cover) }}
             {{ with .Err }}
               {{ warnf "%s" . }}
-            {{ else }}
+            {{ else with .Value }}
               {{ $image := .Params.video.size | default "1200x560 webp" | .Fill }}
               <img src="{{ $image.RelPermalink }}" class="d-block w-100" alt="Cover image" />
+            {{ else }}
+              {{ warnf "Failed to get remote resource: %s" . }}
             {{ end }}
           {{ end }}
         </a>
@@ -160,10 +164,10 @@
               <div class="position-relative text-center">
                 <div class="swap-image">
                   {{/* Get supporters logo image and transform it */}}
-                  {{ with resources.GetRemote $supporters.logo }}
+                  {{ with try (resources.GetRemote $supporters.logo) }}
                     {{ with .Err }}
                       {{ warnf "%s" . }}
-                    {{ else }}
+                    {{ else with .Value }}
                       {{ $image := .Resize "x400 webp" }}
                       {{ $image_gray := $image.Filter images.Grayscale }}
                       <img
@@ -180,6 +184,8 @@
                         alt="{{ $supporters.name }}"
                         class="d-block mb-3 swap-to container-fluid justify-content-center"
                       />
+                    {{ else }}
+                      {{ warnf "Failed to get remote resource: %s" . }}
                     {{ end }}
                   {{ end }}
                   <a
@@ -327,13 +333,17 @@
               <div class="card card-hover border-0 bg-transparent">
                 {{/* Get member's image */}}
                 {{ $image := "" }}
-                {{ with resources.GetRemote $member.image }}
+                {{ with try (resources.GetRemote $member.image) }}
                   {{ with .Err }}
                     {{ warnf "At /about, %s's image is not found: %s" $member.name . }}
-                    {{ with resources.Get "/img/unknown_person.jpg" }}
-                      {{ $image = . }}
-                    {{ else }}
-                      {{ errorf "unknown_person.jpg is not found: %s" . }}
+                    {{ with try (resources.Get "/img/unknown_person.jpg") }}
+                      {{ with .Err }}
+                        {{ errorf "%s" . }}
+                      {{ else with .Value }}
+                        {{ $image = . }}
+                      {{ else }}
+                        {{ errorf "unknown_person.jpg is not found: %s" . }}
+                      {{ end }}
                     {{ end }}
                   {{ end }}
                 {{ end }}

--- a/layouts/partials/_funcs/get-ogp-image.html
+++ b/layouts/partials/_funcs/get-ogp-image.html
@@ -16,10 +16,13 @@
 {{- /*  カルーセルがある場合は取得  */ -}}
 {{- with .Params.carousels }}
   {{- with index . 0 }}
-    {{- with resources.GetRemote .link }}
+    {{- with try (resources.GetRemote .link) }}
       {{- with .Err }}
-      {{- else }}
+        {{ errorf "%s" . }}
+      {{- else with .Value }}
         {{- $image = .Filter (slice (images.GaussianBlur 25) (images.Brightness -25)) }}
+      {{- else }}
+        {{- errorf "Failed to get remote resource: %s" . -}}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/layouts/partials/home/schedule.html
+++ b/layouts/partials/home/schedule.html
@@ -1,5 +1,5 @@
 {{ if .Params.schedule.enable }}
-  {{ $days := "" }}
+  {{ $days := slice }}
   {{ $year := .Params.year }}
   {{ $apiURL := printf "%s?year=%d" .Site.Params.apiURL $year }}
 
@@ -28,11 +28,14 @@
     "method" "get"
     "headers" (dict  "Content-Type" "application/json")
   }}
-  {{ with resources.GetRemote $apiURL $opts }}
+  {{ with try (resources.GetRemote $apiURL $opts) }}
     {{ with .Err }}
-      {{ warnf "Unable to get scuedule info from %s : %s" $apiURL . }}
-    {{ else }}
+      {{ errorf "%s" . }}
+    {{ else with .Value }}
+      {{/* TODO: Support for redirects */}}
       {{ $days = .Content | transform.Unmarshal }}
+    {{ else }}
+      {{ errorf "Unable to get schedule info of year=%d" $year }}
     {{ end }}
   {{ end }}
 
@@ -190,14 +193,22 @@
                           {{ range $teacher := $selected_techers }}
                             {{/* 講師画像の取得と画像処理 */}}
                             {{ $image := "" }}
-                            {{ with resources.GetRemote $teacher.image }}
+                            {{ with try (resources.GetRemote $teacher.image) }}
                               {{ with .Err }}
                                 {{ warnf "Unable to get teacher image from %s : %s" $teacher.image . }}
-                                {{ with resources.Get "img/unknown_person.jpg" }}
-                                  {{ $image = . }}
+                                {{ with try (resources.Get "img/unknown_person.jpg") }}
+                                  {{ with .Err }}
+                                    {{ errorf "%s" . }}
+                                  {{ else with .Value }}
+                                    {{ $image = . }}
+                                  {{ else }}
+                                    {{ errorf "Failed to get default image: img/unknown_person.jpg" }}
+                                  {{ end }}
                                 {{ end }}
-                              {{ else }}
+                              {{ else with .Value }}
                                 {{ $image = . }}
+                              {{ else }}
+                                {{ warnf "Failed to get remote resource: %s" $teacher.image }}
                               {{ end }}
                             {{ end }}
                             {{ $image = $image.Fill "128x128 webp picture" }}

--- a/layouts/partials/home/teachers.html
+++ b/layouts/partials/home/teachers.html
@@ -1,7 +1,7 @@
 {{/* Define Global Variables */}}
 {{ $year := .Params.year }}
 {{ $teachers := "" }}
-{{ $days := "" }}
+{{ $days := slice }}
 {{ $events := slice }}
 {{ $socialIcons := dict
   "twitter" "bxl-twitter"
@@ -85,18 +85,22 @@ events = [
     "method" "get"
     "headers" (dict  "Content-Type" "application/json")
   }}
-  {{ with resources.GetRemote $apiURL $opts }}
+  {{ with try (resources.GetRemote $apiURL $opts) }}
     {{ with .Err }}
-      {{ warnf "Unable to get scuedule info from %s : %s" $apiURL . }}
-    {{ else }}
+      {{ errorf "%s" . }}
+    {{ else with .Value }}
+      {{/* TODO: Support for redirects */}}
       {{ $days = .Content | transform.Unmarshal }}
-      {{/* $eventsに変換 */}}
-      {{ range $day := $days }}
-        {{ range $event := $day.events }}
-          {{ $events = $events | append $event }}
-        {{ end }}
-      {{ end }}
+    {{ else }}
+      {{ errorf "Failed to get remote resource: %s" . }}
     {{ end }}
+  {{ end }}
+{{ end }}
+
+{{/* $eventsに変換 */}}
+{{ range $day := $days }}
+  {{ range $event := $day.events }}
+    {{ $events = $events | append $event }}
   {{ end }}
 {{ end }}
 
@@ -128,19 +132,23 @@ events = [
 
         {{/* Prepare for teacher's image */}}
         {{ $teacher_image := "" }}
-        {{ with resources.GetRemote $teacher.image }}
+        {{ with try (resources.GetRemote $teacher.image) }}
           {{ with .Err }}
             {{ warnf "Unable to get teacher %s's image: %s" $name . }}
             {{/* Get default teacher image */}}
-            {{ with resources.Get "/img/unknown_person.jpg" }}
+            {{ with try (resources.Get "/img/unknown_person.jpg") }}
               {{ with .Err }}
                 {{ errorf "Unable to get default teacher image: %s" . }}
-              {{ else }}
+              {{ else with .Value }}
                 {{ $teacher_image = . }}
+              {{ else }}
+                {{ errorf "Failed to get default teacher image: %s" . }}
               {{ end }}
             {{ end }}
-          {{ else }}
+          {{ else with .Value }}
             {{ $teacher_image = . }}
+          {{ else }}
+            {{ errorf "Failed to get teacher %s's image: %s" $name . }}
           {{ end }}
         {{ end }}
 

--- a/layouts/partials/home/title.html
+++ b/layouts/partials/home/title.html
@@ -17,10 +17,10 @@
       <div class="carousel-inner h-100">
         {{ range $index, $element := .Params.carousels }}
           {{/* Load and Convert a carousel image */}}
-          {{ with resources.GetRemote $element.link }}
+          {{ with try (resources.GetRemote $element.link) }}
             {{ with .Err }}
               {{ warnf "Unable to get carousel image from %s: %s" $element.link . }}
-            {{ else }}
+            {{ else with .Value }}
               {{ $anchor := "" }}
               {{ with $element.anchor }}
                 {{ $anchor = . }}
@@ -44,6 +44,8 @@
                   </div>
                 {{ end }}
               </div>
+            {{ else }}
+              {{ warnf "Failed to get remote resource: %s" $element.link }}
             {{ end }}
           {{ end }}
         {{ end }}

--- a/layouts/partials/home/venues.html
+++ b/layouts/partials/home/venues.html
@@ -21,11 +21,13 @@
               >
                 {{/* Get Venue's image */}}
                 {{ $image := "" }}
-                {{ with resources.GetRemote $venue.image }}
+                {{ with try (resources.GetRemote $venue.image) }}
                   {{ with .Err }}
                     {{ errorf "Unable to get venue %s's image: %s" $venue.name . }}
-                  {{ else }}
+                  {{ else with .Value }}
                     {{ $image = . }}
+                  {{ else }}
+                    {{ errorf "Failed to get remote resource: %s" $venue.image }}
                   {{ end }}
                 {{ end }}
                 {{/* Convert original venue image for card. */}}


### PR DESCRIPTION
I upgraded Hugo to version 0.141.0, which introduces breaking changes (#67).
The issue #65 appears to be resolved, but the redirect problem remains unsolved because hugo does not handle the redirect at the [`resources.GetRemote`](https://gohugo.io/functions/resources/getremote/) function.

So, we need to continue to monitor this closely.