### PR TITLE
Refactor main theme SCSS and update deploy links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 [ci]: https://github.com/plasma-fusion-youth-forum/pfyss/actions/workflows/ci.yaml
 [ci-badge]: https://img.shields.io/github/actions/workflow/status/plasma-fusion-youth-forum/pfyss/ci.yaml?style=flat-square&logo=GitHub&label=CI
-[deploy]: https://github.com/plasma-fusion-youth-forum/pfyss/actions/workflows/hugo.yaml
-[deploy-badge]: https://img.shields.io/github/actions/workflow/status/plasma-fusion-youth-forum/pfyss/hugo.yaml?style=flat-square&logo=GitHub&label=Deploy
+[deploy]: https://github.com/plasma-fusion-youth-forum/pfyss/actions/workflows/deploy.yaml
+[deploy-badge]: https://img.shields.io/github/actions/workflow/status/plasma-fusion-youth-forum/pfyss/deploy.yaml?style=flat-square&logo=GitHub&label=Deploy
 [prettier]: https://github.com/prettier/prettier
 [prettier-badge]: https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square
 

--- a/layouts/partials/site-styles.html
+++ b/layouts/partials/site-styles.html
@@ -1,16 +1,22 @@
 <!-- Main Theme Styles + Bootstrap -->
-{{/* Main theme styles are compiled from the `scss/theme.scss` file
-  and minified using the `dartsass` transpiler.
-*/}}
-{{ $options := dict
-  "transpiler" "dartsass"
-  "targetPath" "css/theme.css"
-  "outputStyle" "compressed"
-  "enableSourceMap" (not hugo.IsProduction)
-  "includePaths" (slice "node_modules")
-}}
-{{ with resources.Get "scss/theme.scss" | toCSS $options | minify | fingerprint }}
-  <link rel="stylesheet" media="screen" href="{{ .RelPermalink }}" />
+{{/* Main theme styles are compiled from the `scss/theme.scss` file. */}}
+{{ with resources.Get "scss/theme.scss" }}
+  {{ $options := dict
+    "transpiler" "dartsass"
+    "targetPath" "css/theme.css"
+    "outputStyle" (cond hugo.IsProduction "compressed" "expanded")
+    "enableSourceMap" (not hugo.IsProduction)
+    "includePaths" (slice "node_modules")
+  }}
+  {{ with . | toCSS $options }}
+    {{ if not hugo.IsProduction }}
+      <link rel="stylesheet" href="{{ .RelPermalink }}" />
+    {{ else }}
+      {{ with . | minify | fingerprint }}
+        <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous" />
+      {{ end }}
+    {{ end }}
+  {{ end }}
 {{ end }}
 
 


### PR DESCRIPTION
Key changes:

- Refactored the Jinja template for the main theme SCSS to improve clarity and maintainability.

- Updated the deploy workflow links in the README.md to point to the correct file.