### PR TITLE
Fix social media links by updating parameter references for Discord and Twitter

### DIFF
--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -35,7 +35,7 @@
                 <p class="mb-0">DiscordとTwitterのDMでも質問・お問い合わせを受け付けています。</p>
                 <div class="d-flex pt-3">
                   <a
-                    href="{{ .Site.Params.socials.discord.url | safeURL }}"
+                    href="{{ .Site.Params.social.discord.url | safeURL }}"
                     target="_blank"
                     rel="noopener noreferrer"
                     class="btn btn-icon btn-secondary btn-discord mx-2"
@@ -43,7 +43,7 @@
                     <i class="bx bxl-discord-alt"></i>
                   </a>
                   <a
-                    href="{{ .Site.Params.socials.twitter.url | safeURL }}"
+                    href="{{ .Site.Params.social.twitter.url | safeURL }}"
                     target="_blank"
                     rel="noopener noreferrer"
                     class="btn btn-icon btn-secondary btn-twitter mx-2"

--- a/layouts/partials/home/discord.html
+++ b/layouts/partials/home/discord.html
@@ -26,7 +26,7 @@
         </p>
         <div class="d-flex flex-column flex-sm-row justify-content-center justify-content-md-start">
           <a
-            href="{{ .Site.Params.socials.discord.url | safeURL }}"
+            href="{{ .Site.Params.social.discord.url | safeURL }}"
             target="_blank"
             rel="noopener noreferrer"
             class="btn btn-primary shadow-primary btn-lg me-sm-4 mb-3"


### PR DESCRIPTION
Updated parameter references for Discord and Twitter links to ensure correct functionality. Key changes include:

- Changed `socials.discord.url` to `social.discord.url`

- Changed `socials.twitter.url` to `social.twitter.url`