### PR TITLE
仲田先生所属修正

### DIFF
--- a/data/2026/teachers.yaml
+++ b/data/2026/teachers.yaml
@@ -26,7 +26,7 @@
 - name: 仲田 資季
   englishName: Motoki Nakata
   position: 教授
-  affiliation: 駒沢大学
+  affiliation: 駒澤大学
   image: https://lh3.googleusercontent.com/pw/AP1GczP1XZjEHhgWtNVredVBxpvfLIywXpHT8iUs3J8dz2rwSyFkLCerK34-_OuDM6UEN0XOyQTYlv38ksD9RT8nYaL1lnw7i3V61QV9ci-IQEhnzvBXAHc=w2400
   description: |
     駒澤大学 総合教育研究部 自然科学部門 教授。<br>


### PR DESCRIPTION
仲田先生の所属大学名を駒沢から駒澤に修正